### PR TITLE
Export Method For Returning Ansi Color Formatted String

### DIFF
--- a/context.go
+++ b/context.go
@@ -93,3 +93,8 @@ func (c *Context) sgr() string {
 	}
 	return values.sgr()
 }
+
+//SGR returns formatted string containing its respective ansi escape codes.
+func (c *Context) SGR() string {
+	return c.sgr()
+}

--- a/context_test.go
+++ b/context_test.go
@@ -23,6 +23,7 @@ func (*contextSuite) newWriter() (*bytes.Buffer, *Writer) {
 func (*contextSuite) TestBlank(c *gc.C) {
 	var context Context
 	c.Assert(context.sgr(), gc.Equals, "")
+	c.Assert(context.SGR(), gc.Equals, "")
 }
 
 func (*contextSuite) TestAllUnknown(c *gc.C) {
@@ -32,21 +33,25 @@ func (*contextSuite) TestAllUnknown(c *gc.C) {
 		Styles:     []Style{456, 99},
 	}
 	c.Assert(context.sgr(), gc.Equals, "")
+	c.Assert(context.SGR(), gc.Equals, "")
 }
 
 func (*contextSuite) TestForeground(c *gc.C) {
 	context := Foreground(Yellow)
 	c.Assert(context.sgr(), gc.Equals, "\x1b[33m")
+	c.Assert(context.SGR(), gc.Equals, "\x1b[33m")
 }
 
 func (*contextSuite) TestBackground(c *gc.C) {
 	context := Background(Blue)
 	c.Assert(context.sgr(), gc.Equals, "\x1b[44m")
+	c.Assert(context.SGR(), gc.Equals, "\x1b[44m")
 }
 
 func (*contextSuite) TestStyles(c *gc.C) {
 	context := Styles(Bold, Italic)
 	c.Assert(context.sgr(), gc.Equals, "\x1b[1;3m")
+	c.Assert(context.SGR(), gc.Equals, "\x1b[1;3m")
 }
 
 func (*contextSuite) TestValid(c *gc.C) {
@@ -56,24 +61,28 @@ func (*contextSuite) TestValid(c *gc.C) {
 		Styles:     []Style{Bold, Italic},
 	}
 	c.Assert(context.sgr(), gc.Equals, "\x1b[1;3;33;44m")
+	c.Assert(context.SGR(), gc.Equals, "\x1b[1;3;33;44m")
 }
 
 func (*contextSuite) TestSetForeground(c *gc.C) {
 	var context Context
 	context.SetForeground(Yellow)
 	c.Assert(context.sgr(), gc.Equals, "\x1b[33m")
+	c.Assert(context.SGR(), gc.Equals, "\x1b[33m")
 }
 
 func (*contextSuite) TestSetBackground(c *gc.C) {
 	var context Context
 	context.SetBackground(Blue)
 	c.Assert(context.sgr(), gc.Equals, "\x1b[44m")
+	c.Assert(context.SGR(), gc.Equals, "\x1b[44m")
 }
 
 func (*contextSuite) TestSetStyles(c *gc.C) {
 	var context Context
 	context.SetStyle(Bold, Italic)
 	c.Assert(context.sgr(), gc.Equals, "\x1b[1;3m")
+	c.Assert(context.SGR(), gc.Equals, "\x1b[1;3m")
 }
 
 func (s *contextSuite) TestFprintfNoColor(c *gc.C) {


### PR DESCRIPTION
- In some usecases there is a need to retain a string with its ansi escape sequence, for writing out later.